### PR TITLE
fix: correct find_packages wildcard behaviour

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     author="Dr. Hicham Badri",
     author_email="hicham@mobiuslabs.com",
     license="Apache 2",
-    packages=find_packages(include=["hqq", "hqq/*"]),
+    packages=find_packages(include=["hqq", "hqq.*"]),
     cmdclass={
         "install": InstallCommand,
         "develop": DevelopCommand,


### PR DESCRIPTION
Hi there!

A very minor PR to fix the wildcard behaviour in setup.py. `find_packages` is quite tricky with things like that. Its parsing expects Python package/subpackage/modules, not paths, so the current format makes it build an empty lib (just the root `__init__.py` as it tries to find packages called `hqq/` rather than `hqq.*`.

This minor change fixes that and properly builds everything.