### PR TITLE
Initializing the model from state_dict

### DIFF
--- a/hqq/core/quantize.py
+++ b/hqq/core/quantize.py
@@ -408,7 +408,7 @@ class HQQLinear(nn.Module):
         torch.cuda.empty_cache()
 
     def extra_repr(self) -> str:
-        in_features, out_features = self.W_q.t().shape if self.W_q else ("uninitialized", "uninitialized")
+        in_features, out_features = self.W_q.t().shape if self.W_q is not None else ("uninitialized", "uninitialized")
         return f'in_features={in_features}, out_features={out_features}, bias={self.bias is not None}'
 
     # Set backends

--- a/hqq/core/quantize.py
+++ b/hqq/core/quantize.py
@@ -512,8 +512,12 @@ class HQQLinear(nn.Module):
         # TODO: later
         return self
 
-    def state_dict(self, *args, **kwargs):
-        return {"W_q": self.W_q, "meta": self.meta, "bias": self.bias}
+    def state_dict(self, *args, **kwargs):  # nn.Module override compatible
+        state = {"W_q": self.W_q, "meta": self.meta, "bias": self.bias}
+        if "destination" in kwargs and "prefix" in kwargs:
+            for key, value in state.items():
+                kwargs["destination"][kwargs["prefix"] + key] = value
+        return state
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
         W_q_key = prefix + "W_q"

--- a/hqq/core/quantize.py
+++ b/hqq/core/quantize.py
@@ -371,6 +371,8 @@ class HQQLinear(nn.Module):
         self.ready = False
         self.in_gpu = False
         self.bias = None
+        self.W_q = None
+        self.meta = None
         self.device = device
         self.compute_dtype = compute_dtype
         self.quant_config = copy.deepcopy(quant_config)
@@ -404,6 +406,10 @@ class HQQLinear(nn.Module):
         if self.del_orig:
             del self.linear_layer
         torch.cuda.empty_cache()
+
+    def extra_repr(self) -> str:
+        in_features, out_features = self.W_q.t().shape if self.W_q else ("uninitialized", "uninitialized")
+        return f'in_features={in_features}, out_features={out_features}, bias={self.bias is not None}'
 
     # Set backends
     @classmethod
@@ -508,6 +514,27 @@ class HQQLinear(nn.Module):
 
     def state_dict(self, *args, **kwargs):
         return {"W_q": self.W_q, "meta": self.meta, "bias": self.bias}
+
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs):
+        W_q_key = prefix + "W_q"
+        meta_key = prefix + "meta"
+        bias_key = prefix + "bias"
+
+        if W_q_key not in state_dict:
+            missing_keys.append(W_q_key)
+        if meta_key not in state_dict:
+            missing_keys.append(meta_key)
+        if missing_keys:
+            return  # Can't load weights if either weight or meta is missing
+
+        W_q = nn.Parameter(state_dict.pop(W_q_key), requires_grad=False)
+        meta = state_dict.pop(meta_key)
+        bias = state_dict.pop(bias_key, None)
+
+        unexpected_keys += state_dict.keys()
+
+        self.load_state_dict({"W_q": W_q, "meta": meta, "bias": bias}, strict)
+
 
     def load_state_dict(self, state_dict, strict=True, assign=False):
         self.W_q = state_dict["W_q"]


### PR DESCRIPTION
Issue #50 

TL;DR, allows loading state_dict from and into a custom model:
```
model = CustomLlamaModel(cfg)
state_dict = model.state_dict()

loaded_model = CustomLlamaModel(cfg)
loaded_model.load_state_dict(state_dict)
```

Longer example with actual quantization:
```
from transformers.models.mixtral.modeling_mixtral import *
from hqq.core.quantize import *
from safetensors import safe_open
from hqq.core.quantize import Quantizer


def hqq_init(self, config: MixtralConfig):
    nn.Module.__init__(self)
    self.ffn_dim = config.intermediate_size
    self.hidden_dim = config.hidden_size

    qcfg = BaseQuantizeConfig(nbits=3, group_size=64)
    self.w1 = HQQLinear(None, quant_config=qcfg)
    self.w2 = HQQLinear(None, quant_config=qcfg)
    self.w3 = HQQLinear(None, quant_config=qcfg)
    self.act_fn = ACT2FN[config.hidden_act]

MixtralBlockSparseTop2MLP.__init__ = hqq_init

tensors = {}
for i in range(1, 20):
    path = MODEL_DIR + f"/models--mistralai--Mixtral-8x7B-Instruct-v0.1/snapshots/1e637f2d7cb0a9d6fb1922f305cb784995190a83/model-{i:0>{5}}-of-00019.safetensors"

    with safe_open(path, framework="pt", device="cpu") as f:
        for k in f.keys():
            tensor = f.get_tensor(k)
            if "expert" in k:
                print("quantizising:", k)
                W_q, meta = Quantizer.quantize(tensor, nbits=3, group_size=64)
                meta.update({"quant_scale": False, "quant_zero": False})
                print(torch.max(W_q, dim=1))
                print(meta)
                tensors[str(k).replace(".weight", ".W_q")] = W_q
                tensors[str(k).replace(".weight", ".meta")] = meta
            else:
                tensors[k] = tensor

modified_model = MixtralForCausalLM(config=MixtralConfig())

modified_model.load_state_dict(tensors)
```

resulting model: `modified_model.to("cuda", dtype=torch.float16)`
```
MixtralForCausalLM(
  (model): MixtralModel(
    (embed_tokens): Embedding(32000, 4096)
    (layers): ModuleList(
      (0-31): 32 x MixtralDecoderLayer(
        (self_attn): MixtralSdpaAttention(
          (q_proj): Linear(in_features=4096, out_features=4096, bias=False)
          (k_proj): Linear(in_features=4096, out_features=1024, bias=False)
          (v_proj): Linear(in_features=4096, out_features=1024, bias=False)
          (o_proj): Linear(in_features=4096, out_features=4096, bias=False)
          (rotary_emb): MixtralRotaryEmbedding()
        )
        (block_sparse_moe): MixtralSparseMoeBlock(
          (gate): Linear(in_features=4096, out_features=8, bias=False)
          (experts): ModuleList(
            (0-7): 8 x MixtralBlockSparseTop2MLP(
              (w1): HQQLinear(in_features=917504, out_features=16, bias=False)
              (w2): HQQLinear(in_features=917504, out_features=16, bias=False)
              (w3): HQQLinear(in_features=917504, out_features=16, bias=False)
              (act_fn): SiLU()
            )
          )
        )
        (input_layernorm): MixtralRMSNorm()
        (post_attention_layernorm): MixtralRMSNorm()
      )
    )
    (norm): MixtralRMSNorm()
  )
  (lm_head): Linear(in_features=4096, out_features=32000, bias=False)
)
```

inference: 
```
%%time

prompt = "how to split atoms?"
inputs = tokenizer(prompt, return_tensors="pt").to("cuda")

outputs = modified_model.generate(**inputs, max_new_tokens=200)
print(tokenizer.decode(outputs[0], skip_special_tokens=True))
```
results in:
```
Setting `pad_token_id` to `eos_token_id`:2 for open-end generation.

how to split atoms?

Atoms are the basic units of a particular chemical element. They cannot be split into smaller units.

However, atoms can be converted into other atoms or into more complex molecules through chemical reactions. For example, hydrogen atoms can be combined with oxygen atoms to form water molecules (H2O) through a chemical reaction called electrolysis.

It's also possible to split atoms in a process called nuclear fission. In a nuclear reactor, a neutron is fired at a uranium atom, which causes the atom to split and release a large amount of energy. This process is used to generate nuclear power.

However, it's important to note that splitting atoms is a highly complex and dangerous process that should only be carried out by trained professionals in a controlled environment.
CPU times: user 18.2 s, sys: 77.4 ms, total: 18.2 s
Wall time: 18.3 s
```