### PR TITLE
pass along cache_dir during snapshot download

### DIFF
--- a/hqq/engine/base.py
+++ b/hqq/engine/base.py
@@ -79,7 +79,7 @@ class HQQWrapper:
         adapter: str = None,
     ):
         # Both local and hub-support
-        save_dir = BaseHQQModel.try_snapshot_download(save_dir_or_hub)
+        save_dir = BaseHQQModel.try_snapshot_download(save_dir_or_hub, cache_dir)
         arch_key = cls._get_arch_key_from_save_dir(save_dir)
         cls._check_arch_support(arch_key)
 


### PR DESCRIPTION
HQQModelForCausalLM.from_quantized() accepts a parameter "cache_dir: str" to be used as the dir to write to when downloading from the HF Hub.

Pass along "cache_dir" to "try_snapshot_download" so it is actually used (otherwise it does nothing)