### PR TITLE
axis fix

### DIFF
--- a/hqq/core/quantize.py
+++ b/hqq/core/quantize.py
@@ -821,6 +821,7 @@ def hqq_base_quant_config(
     quant_scale: bool = False,
     offload_meta: bool = False,  # meta-data should be quantized with the same settings to use offload_meta
     view_as_float: bool = False,
+    axis: int = 0,
 ):
     assert (
         nbits in Quantizer.SUPPORTED_BITS
@@ -836,6 +837,7 @@ def hqq_base_quant_config(
         "optimize": True,
         "round_zero": True if nbits == 4 else False,
         "view_as_float": view_as_float,
+        "axis": axis,
     }
 
     if offload_meta:


### PR DESCRIPTION
When loading the model:
```
AutoModelForCausalLM.from_pretrained(
            pretrained_model_name_or_path=model_name,
            quantization_config=HqqConfig(**{'nbits': 4, 'group_size': 64, 'quant_zero': False, 'quant_scale': False}),
            device_map="cuda",
            torch_dtype=torch.bfloat16
)
```

It runs into:

```
--> 237     self.quant_config = HQQBaseQuantizeConfig(
    238         **{
    239             "nbits": nbits,
    240             "group_size": group_size,
    241             "quant_zero": quant_zero,
    242             "quant_scale": quant_scale,
    243             "offload_meta": offload_meta,
    244             "view_as_float": view_as_float,
    245             "axis": axis,
    246         }
    247     )
    249 self.quant_method = QuantizationMethod.HQQ
    250 self.skip_modules = skip_modules

TypeError: hqq_base_quant_config() got an unexpected keyword argument 'axis'
```