### PR TITLE
Fix hf load

### DIFF
--- a/hqq/core/quantize.py
+++ b/hqq/core/quantize.py
@@ -458,7 +458,7 @@ class HQQLinear(nn.Module):
                 _, self.meta["meta_zero"] = Quantizer.cuda(
                     None, self.meta["meta_zero"], device
                 )
-        else:
+        elif "zero" in self.meta:
             self.meta["zero"] = self.meta["zero"].to(device)
 
         if self.meta["quant_scale"]:
@@ -470,7 +470,7 @@ class HQQLinear(nn.Module):
                 _, self.meta["meta_scale"] = Quantizer.cuda(
                     None, self.meta["meta_scale"], device
                 )
-        else:
+        elif "scale" in self.meta:
             self.meta["scale"] = self.meta["scale"].to(device)
 
         # #Use zero/scale with streams for dequantization is faster than packing in "zero_scale"

--- a/hqq/models/hf/base.py
+++ b/hqq/models/hf/base.py
@@ -14,13 +14,13 @@ class BaseHQQHFModel(BaseHQQModel):
     # Create empty model from config
     @classmethod
     def create_model(cls, save_dir, kwargs):
-        config_kwargs = {}
+        model_kwargs = {}
         for key in ["attn_implementation"]:
             if key in kwargs:
-                config_kwargs[key] = kwargs[key]
+                model_kwargs[key] = kwargs[key]
 
         config = transformers.AutoConfig.from_pretrained(
-            cls.get_config_file(save_dir), **config_kwargs
+            cls.get_config_file(save_dir)
         )
 
         auto_class = transformers.AutoModel
@@ -31,7 +31,7 @@ class BaseHQQHFModel(BaseHQQModel):
             auto_class = transformers.AutoModelForCausalLM
 
         with init_empty_weights():
-            model = auto_class.from_config(config)
+            model = auto_class.from_config(config, **model_kwargs)
 
         return model
 


### PR DESCRIPTION
If we save quantized model with this config

```python
#Load the model on CPU
import torch
from transformers import AutoModelForCausalLM
model = AutoModelForCausalLM.from_pretrained('meta-llama/Meta-Llama-3-8B', torch_dtype=torch.bfloat16)

#Quantize
from hqq.core.quantize import BaseQuantizeConfig
from hqq.models.hf.base import AutoHQQHFModel
quant_config = BaseQuantizeConfig(nbits=4, group_size=64, quant_scale=False, quant_zero=False, axis=1, offload_meta=True) 
model = AutoHQQHFModel.quantize_model(model, quant_config=quant_config, compute_dtype=torch.bfloat16, device='cuda:0')

AutoHQQHFModel.save_quantized(model, 'llama3-hqq')
```

Then trying to load the quantized model

```python
model = AutoHQQHFModel.from_quantized('llama3-hqq', compute_dtype=torch.bfloat16, attn_implementation='flash_attention_2')
```

We will got error saying that `zero` is not in `meta` because we set `offload_meta=True`. This PR fix it.

This PR also fix when trying to load quantized model with `attn_implementation`. Because current transformers somehow ignore `attn_implementation` if load from `AutoConfig.from_pretrained`. So, I move it to `auto_class.from_config`