### PR TITLE
Add way to save quantize config and can be loaded again

### DIFF
--- a/hqq/models/base.py
+++ b/hqq/models/base.py
@@ -398,7 +398,7 @@ class BaseHQQModel:
     @classmethod
     def save_patch_params(cls, model, save_dir: str):
 
-        with open(os.path.join(save_dir, 'quantize_config.json'), 'w') as f:
+        with open(cls.get_patch_params_file(save_dir), 'w') as f:
             json.dump(model.patch_params, f, indent=2)
 
     # Prepares model weights by iterating through modules. It might some parameters that are NOT modules like model.param1


### PR DESCRIPTION
Because `quant_config` is gone when you load model using `from_quantized`. I tried to re-add the `quant_config` here so then when we call `prepare_for_inference` for loaded quantized model, it will not crash because `quant_config` not found.