### PR TITLE
Fix filename in `setup_torch.py`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,16 @@ To get the latest version, you can install the core library directly via ```pip 
 
 Alternatively, clone the repo and run ```pip install .``` from this current folder. 
 
+Alternatively, clone the repo and run ```pip install .``` from this current folder. 
+
+To use `HQQBackend.ATEN` you also need to run one of these:  
+```
+python {hqq installation path}/kernels/setup_cuda.py install
+```  
+```
+python {hqq installation path}/kernels/setup_torch.py install
+```
+
 ### Basic Usage
 To perform quantization with HQQ, you simply need to replace the linear layers ( ```torch.nn.Linear```) as follows:
 ```Python

--- a/Readme.md
+++ b/Readme.md
@@ -44,16 +44,6 @@ To get the latest version, you can install the core library directly via ```pip 
 
 Alternatively, clone the repo and run ```pip install .``` from this current folder. 
 
-Alternatively, clone the repo and run ```pip install .``` from this current folder. 
-
-To use `HQQBackend.ATEN` you also need to run one of these:  
-```
-python {hqq installation path}/kernels/setup_cuda.py install
-```  
-```
-python {hqq installation path}/kernels/setup_torch.py install
-```
-
 ### Basic Usage
 To perform quantization with HQQ, you simply need to replace the linear layers ( ```torch.nn.Linear```) as follows:
 ```Python

--- a/hqq/kernels/setup_torch.py
+++ b/hqq/kernels/setup_torch.py
@@ -3,7 +3,7 @@ from torch.utils import cpp_extension
 
 setup(
     name="hqq_aten",
-    ext_modules=[cpp_extension.CppExtension("hqq_aten", ["hqq_aten.cpp"])],
+    ext_modules=[cpp_extension.CppExtension("hqq_aten", ["hqq_aten_torch.cpp"])],
     extra_compile_args=["-O3"],
     cmdclass={"build_ext": cpp_extension.BuildExtension},
 )


### PR DESCRIPTION
`setup_torch.py` used `hqq_aten.cpp` filename but there's only `hqq_aten_torch.cpp` currently. 

would also be nice to update README with instructions on how to setup `hqq_aten`