### PR TITLE
Fix SDPA context manager perf regression

### DIFF
--- a/hqq/utils/generation_hf.py
+++ b/hqq/utils/generation_hf.py
@@ -77,7 +77,7 @@ def patch_model_for_compiled_runtime(
             "input_ids" in kwargs and kwargs["input_ids"].shape[-1] == 1
         ):
             out_fct = forward_compiled
-        with sdpa_kernel([SDPBackend.MATH, SDPBackend.FLASH_ATTENTION]):
+        with sdpa_kernel([SDPBackend.MATH]):
             out = out_fct(*args, **kwargs)
         return out
 
@@ -184,7 +184,7 @@ class HFGenerator:
             self.model.forward, mode="reduce-overhead", fullgraph=True
         )
 
-        with sdpa_kernel([SDPBackend.MATH, SDPBackend.FLASH_ATTENTION]):
+        with sdpa_kernel([SDPBackend.MATH]):
             for ctx_size in [1] * 10:
                 self.model(
                     torch.ones(
@@ -316,7 +316,7 @@ class HFGenerator:
 
     # generate one token at a time
     def gen_next_token(self, next_token):
-        with sdpa_kernel([SDPBackend.MATH, SDPBackend.FLASH_ATTENTION]):
+        with sdpa_kernel([SDPBackend.MATH]):
             next_token = self.decode_one_token(
                 next_token.clone(),
                 None,


### PR DESCRIPTION
Funnily enough this also improved the perf baseline on H100 for 2.5 to match 2.4. The main problem was the old context manager was not using the math backend which is faster at small batch sizes

Basically the old context manager you'd need to set backends you don't want, so when a new backend gets added like cudnn the behavior changes 

Side benefit: no more warning spews for the deprecated API and the uninstalled backends
```
(warn) [marksaroufim@devgpu003.cco3 ~/tinygemm]$ python t.py 
Loading checkpoint shards: 100%|███████| 2/2 [00:01<00:00,  1.94it/s]
100%|█████████████████████████████| 131/131 [00:00<00:00, 189.94it/s]
100%|██████████████████████████████| 225/225 [00:25<00:00,  8.86it/s]
 84%|█████████████████████████▎    | 844/999 [00:23<00:04, 36.25it/s]
  6%|█▋                            | 57/999 [00:00<00:08, 107.56it/s]
 85%|████████████████████████▌    | 846/999 [00:03<00:00, 257.36it/s]
 63%|██████████████████▎          | 630/999 [00:02<00:01, 257.03it/s]
 16%|████▌                        | 157/999 [00:00<00:03, 255.79it/s]
100%|████████████████████████████▉| 996/999 [00:03<00:00, 257.29it/s]
(warn) [marksaroufim@devgpu003.cco3 ~/tinygemm]$ 
```