### PR TITLE
Bug fix: Specify device/map_location when loading weights using device="cpu"

### DIFF
--- a/hqq/models/base.py
+++ b/hqq/models/base.py
@@ -478,7 +478,7 @@ class BaseHQQModel:
 
         # Load weights
         try:
-            weights = cls.load_weights(save_dir)
+            weights = cls.load_weights(save_dir, device)
         except Exception:
             print("Failed to load the weights")
             raise FileNotFoundError


### PR DESCRIPTION
Loading a model on cpu, as demonstrated below, fails.

```python
from hqq.models.hf.base import AutoHQQHFModel
model = AutoHQQHFModel.from_quantized("model_path", device="cpu")
```

This results in the following error
```
Failed to load the weights
Traceback (most recent call last):
  File "/home/aikkala/workspace/projects/hqq-fork/hqq/models/base.py", line 481, in from_quantized
    weights = cls.load_weights(save_dir)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/workspace/projects/hqq-fork/hqq/models/base.py", line 251, in load_weights
    return torch.load(cls.get_weight_file(save_dir), map_location=map_location)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/serialization.py", line 1462, in load
    return _load(
           ^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/serialization.py", line 1964, in _load
    result = unpickler.load()
             ^^^^^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/_weights_only_unpickler.py", line 512, in load
    self.append(self.persistent_load(pid))
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/serialization.py", line 1928, in persistent_load
    typed_storage = load_tensor(
                    ^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/serialization.py", line 1900, in load_tensor
    wrap_storage=restore_location(storage, location),
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/serialization.py", line 693, in default_restore_location
    result = fn(storage, location)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/serialization.py", line 631, in _deserialize
    device = _validate_device(location, backend_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/site-packages/torch/serialization.py", line 600, in _validate_device
    raise RuntimeError(
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/miniconda3/envs/hqq-fork/lib/python3.12/runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "/home/aikkala/.vscode-server/extensions/ms-python.debugpy-2024.14.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 71, in <module>
    cli.main()
  File "/home/aikkala/.vscode-server/extensions/ms-python.debugpy-2024.14.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 501, in main
    run()
  File "/home/aikkala/.vscode-server/extensions/ms-python.debugpy-2024.14.0-linux-x64/bundled/libs/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 351, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/home/aikkala/.vscode-server/extensions/ms-python.debugpy-2024.14.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 310, in run_path
    return _run_module_code(code, init_globals, run_name, pkg_name=pkg_name, script_name=fname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/.vscode-server/extensions/ms-python.debugpy-2024.14.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 127, in _run_module_code
    _run_code(code, mod_globals, init_globals, mod_name, mod_spec, pkg_name, script_name)
  File "/home/aikkala/.vscode-server/extensions/ms-python.debugpy-2024.14.0-linux-x64/bundled/libs/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 118, in _run_code
    exec(code, run_globals)
  File "/home/aikkala/workspace/projects/hqq-fork/examples/hf/load_cpu_model.py", line 7, in <module>
    model = AutoHQQHFModel.from_quantized(model_path, device="cpu")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aikkala/workspace/projects/hqq-fork/hqq/models/base.py", line 484, in from_quantized
    raise FileNotFoundError
FileNotFoundError
```

This merge request proposes a simple fix to specify the device when loading weights.
