### PR TITLE
Add support to load quantized SequenceClassification models

### DIFF
--- a/hqq/models/hf/base.py
+++ b/hqq/models/hf/base.py
@@ -9,6 +9,9 @@ class BaseHQQHFModel(BaseHQQModel):
     # Save model architecture
     @classmethod
     def cache_model(cls, model, save_dir):
+        # Update model architecture in the config
+        model.config.architectures = [model.__class__.__name__]
+        # Save config
         model.config.save_pretrained(save_dir)
 
     # Create empty model from config
@@ -27,8 +30,11 @@ class BaseHQQHFModel(BaseHQQModel):
 
         # Todo: add support for other auto models
         archs = config.architectures
-        if len(archs) == 1 and ("CausalLM" in archs[0]):
-            auto_class = transformers.AutoModelForCausalLM
+        if len(archs) == 1:
+            if ("CausalLM" in archs[0]):
+                auto_class = transformers.AutoModelForCausalLM
+            elif ("SequenceClassification" in archs[0]):
+                auto_class = transformers.AutoModelForSequenceClassification
 
         with init_empty_weights():
             model = auto_class.from_config(config, **model_kwargs)


### PR DESCRIPTION
This PR proposes a simple modification to load quantized `SequenceClassification` auto models. I haven't tested this extensively, but works at least with `LlamaForSequenceClassification`.

The model architecture is updated into the config in `hqq.models.hf.base.BaseHQQHFModel`'s _cache_model_ similarly to what is done in [HuggingFace's _save_pretrained_](https://github.com/huggingface/transformers/blob/7eecdf2a8650306ed5fbb6150c64f99f587e004d/src/transformers/modeling_utils.py#L2754C9-L2754C80) method