### PR TITLE
fix: Add missing beta *= kappa increment in proximal legacy solver

### DIFF
--- a/hqq/core/optimize.py
+++ b/hqq/core/optimize.py
@@ -246,6 +246,8 @@ def optimize_weights_proximal_legacy(
         else:
             break
 
+        beta *= kappa
+
     scale = scale.to(tensor.device)
     zero = zero.to(tensor.device)
     del W_f, W_q, W_r


### PR DESCRIPTION
`kappa` is extracted from [`opt_params`](https://github.com/mobiusml/hqq/blob/df1a4fe/hqq/core/optimize.py#L219-L223) but never applied. `beta` stays fixed throughout the loop.

The paper's proximal solver requires:

$$\beta^{(t+1)} = \kappa \cdot \beta^{(t)}$$                                                                                                                                                 

This geometric increase gradually shifts weight from the $L_p$ regularizer toward the quantization constraint, ensuring convergence. Without it, the balance between regularization and quantization never changes.

TorchAO's independent re-implementation includes this increment ([quant_primitives.py#L1836](https://github.com/pytorch/ao/blob/main/torchao/quantization/quant_primitives.py#L1836)).

This patch adds `beta *= kappa` after the early-stop check.